### PR TITLE
Read address version as unsigned integer

### DIFF
--- a/lib/hdprivatekey.js
+++ b/lib/hdprivatekey.js
@@ -341,7 +341,7 @@ HDPrivateKey._validateNetwork = function(data, networkArg) {
     return new errors.InvalidNetworkArgument(networkArg);
   }
   var version = data.slice(0, 4);
-  if (BufferUtil.integerFromBuffer(version) !== network.xprivkey) {
+  if (BufferUtil.unsignedIntegerFromBuffer(version) !== network.xprivkey) {
     return new errors.InvalidNetwork(version);
   }
   return null;
@@ -477,7 +477,7 @@ HDPrivateKey.prototype._buildFromBuffers = function(arg) {
     }
   }
 
-  var network = Network.get(BufferUtil.integerFromBuffer(arg.version));
+  var network = Network.get(BufferUtil.unsignedIntegerFromBuffer(arg.version));
   var xprivkey;
   xprivkey = Base58Check.encode(buffer.Buffer.concat(sequence));
   arg.xprivkey = new Buffer(xprivkey);
@@ -576,7 +576,7 @@ HDPrivateKey.prototype.inspect = function() {
  */
 HDPrivateKey.prototype.toObject = HDPrivateKey.prototype.toJSON = function toObject() {
   return {
-    network: Network.get(BufferUtil.integerFromBuffer(this._buffers.version), 'xprivkey').name,
+    network: Network.get(BufferUtil.unsignedIntegerFromBuffer(this._buffers.version), 'xprivkey').name,
     depth: BufferUtil.integerFromSingleByteBuffer(this._buffers.depth),
     fingerPrint: BufferUtil.integerFromBuffer(this.fingerPrint),
     parentFingerPrint: BufferUtil.integerFromBuffer(this._buffers.parentFingerPrint),

--- a/lib/hdpublickey.js
+++ b/lib/hdpublickey.js
@@ -256,7 +256,7 @@ HDPublicKey._validateNetwork = function(data, networkArg) {
     return new errors.InvalidNetworkArgument(networkArg);
   }
   var version = data.slice(HDPublicKey.VersionStart, HDPublicKey.VersionEnd);
-  if (BufferUtil.integerFromBuffer(version) !== network.xpubkey) {
+  if (BufferUtil.unsignedIntegerFromBuffer(version) !== network.xpubkey) {
     return new errors.InvalidNetwork(version);
   }
   return null;
@@ -266,7 +266,7 @@ HDPublicKey.prototype._buildFromPrivate = function (arg) {
   var args = _.clone(arg._buffers);
   var point = Point.getG().mul(BN.fromBuffer(args.privateKey));
   args.publicKey = Point.pointToCompressed(point);
-  args.version = BufferUtil.integerAsBuffer(Network.get(BufferUtil.integerFromBuffer(args.version)).xpubkey);
+  args.version = BufferUtil.integerAsBuffer(Network.get(BufferUtil.unsignedIntegerFromBuffer(args.version)).xpubkey);
   args.privateKey = undefined;
   args.checksum = undefined;
   args.xprivkey = undefined;
@@ -344,7 +344,7 @@ HDPublicKey.prototype._buildFromBuffers = function(arg) {
       throw new errors.InvalidB58Checksum(concat, checksum);
     }
   }
-  var network = Network.get(BufferUtil.integerFromBuffer(arg.version));
+  var network = Network.get(BufferUtil.unsignedIntegerFromBuffer(arg.version));
 
   var xpubkey;
   xpubkey = Base58Check.encode(BufferUtil.concat(sequence));
@@ -430,7 +430,7 @@ HDPublicKey.prototype.inspect = function() {
  */
 HDPublicKey.prototype.toObject = HDPublicKey.prototype.toJSON = function toObject() {
   return {
-    network: Network.get(BufferUtil.integerFromBuffer(this._buffers.version)).name,
+    network: Network.get(BufferUtil.unsignedIntegerFromBuffer(this._buffers.version)).name,
     depth: BufferUtil.integerFromSingleByteBuffer(this._buffers.depth),
     fingerPrint: BufferUtil.integerFromBuffer(this.fingerPrint),
     parentFingerPrint: BufferUtil.integerFromBuffer(this._buffers.parentFingerPrint),

--- a/lib/util/buffer.js
+++ b/lib/util/buffer.js
@@ -124,6 +124,17 @@ module.exports = {
   },
 
   /**
+   * Transform the first 4 values of a Buffer into a unsigned number, in little endian encoding
+   *
+   * @param {Buffer} buffer
+   * @return {number}
+   */
+  unsignedIntegerFromBuffer: function unsignedIntegerFromBuffer(buffer) {
+    $.checkArgumentType(buffer, 'Buffer', 'buffer');
+    return buffer.readUInt32BE(0);
+  },
+
+  /**
    * Transforms the first byte of an array into a number ranging from -128 to 127
    * @param {Buffer} buffer
    * @return {number}


### PR DESCRIPTION
That prevents large address versions to be read as negative numbers and failing to lookup the correct network from the Networks map.